### PR TITLE
check if STTS is installed and configured before trying to call the executable

### DIFF
--- a/DCS-SimpleTextToSpeech.lua
+++ b/DCS-SimpleTextToSpeech.lua
@@ -1,7 +1,7 @@
 --[[
 
 DCS-SimpleTextToSpeech
-Version 0.4
+Version 0.4.1
 Compatible with SRS version 1.9.6.0 +
 
 DCS Modification Required:
@@ -73,6 +73,30 @@ STTS.GOOGLE_CREDENTIALS = "C:\\Users\\Ciaran\\Downloads\\googletts.json"
 STTS.EXECUTABLE = "DCS-SR-ExternalAudio.exe"
 
 local random = math.random
+
+STTS.configuredAndInstalled = nil
+---Checks if the STTS system is setup (.exe program installed and accessible, constants set) and caches the result
+---@return boolean if true, the STTS system is configured and installed, and can be used.
+function STTS.isConfiguredAndInstalled()
+    if STTS.configuredAndInstalled ~= nil then
+        return STTS.configuredAndInstalled
+    end
+
+    STTS.configuredAndInstalled = false
+
+    if STTS.DIRECTORY and STTS.EXECUTABLE then
+        local sttsExePath = STTS.DIRECTORY .. "\\" .. STTS.EXECUTABLE
+        local sttsFile=io.open(sttsExePath,"r")
+        if sttsFile~=nil then
+            io.close(sttsFile)
+            STTS.configuredAndInstalled = true
+        end
+    end
+
+    env.info(string.format("[DCS-STTS] STTS.configuredAndInstalled = %s", STTS.configuredAndInstalled))
+    return STTS.configuredAndInstalled
+end
+
 function STTS.uuid()
     local template ='yxxx-xxxxxxxxxxxx'
     return string.gsub(template, '[xy]', function (c)
@@ -126,6 +150,12 @@ end
 function STTS.TextToSpeech(message,freqs,modulations, volume,name, coalition,point, speed,gender,culture,voice, googleTTS )
     if os == nil or io == nil then 
         env.info("[DCS-STTS] LUA modules os or io are sanitized. skipping. ")
+        return 
+    end
+
+
+    -- check if the STTS system is setup (.exe program installed and accessible, constants set) and exit if it is not
+    if not STTS.isConfiguredAndInstalled() then
         return 
     end
 
@@ -196,6 +226,11 @@ function STTS.TextToSpeech(message,freqs,modulations, volume,name, coalition,poi
 end
 
 function STTS.PlayMP3(pathToMP3,freqs,modulations, volume,name, coalition,point )
+
+    -- check if the STTS system is setup (.exe program installed and accessible, constants set) and exit if it is not
+    if not STTS.isConfiguredAndInstalled() then
+        return
+    end
 
     local cmd = string.format("start \"\" /d \"%s\" /b /min \"%s\" -i \"%s\" -f %s -m %s -c %s -p %s -n \"%s\" -v %s -h", STTS.DIRECTORY, STTS.EXECUTABLE, pathToMP3, freqs, modulations, coalition,STTS.SRS_PORT, name, volume )
     

--- a/DCS-SimpleTextToSpeech.lua
+++ b/DCS-SimpleTextToSpeech.lua
@@ -93,7 +93,12 @@ function STTS.isConfiguredAndInstalled()
         end
     end
 
-    env.info(string.format("[DCS-STTS] STTS.configuredAndInstalled = %s", STTS.configuredAndInstalled))
+    local configuredAndInstalled = "false"
+    if STTS.configuredAndInstalled then
+        configuredAndInstalled = "true"
+    end
+    env.info(string.format("[DCS-STTS] STTS.configuredAndInstalled = %s", configuredAndInstalled))
+    
     return STTS.configuredAndInstalled
 end
 


### PR DESCRIPTION
If the user add the STTS script to a mission and configures it (sets up the directory and port), but somehow the executable itself is not available (was not installed, has been moved, is not accessible by the current user, etc.), then an error pops up and DCS is frozen.

This little change ensures that, the first time STTS is used, it will check if the executable file is actually there.
Then, this information is cached for better performance.